### PR TITLE
Changed getPrevScope to getCurrentScope in the compoundMessagePronoun for PREV

### DIFF
--- a/src/EU4/Handlers.hs
+++ b/src/EU4/Handlers.hs
@@ -525,7 +525,7 @@ compoundMessagePronoun stmt@[pdx| $head = @scr |] = withCurrentIndent $ \i -> do
                     Just EU4Geographic -> Just MsgROOTGeographic
                     _ -> Nothing) -- warning printed below
         "prev" -> do
-                newscope <- getPrevScope
+                newscope <- getCurrentScope
                 return (newscope, case newscope of
                     Just EU4Country -> Just MsgPREVCountry
                     Just EU4Province -> Just MsgPREVProvince


### PR DESCRIPTION
compoundMessagePronoun only adds the scope to the scopestack AFTER checking what type of scope it refers to. In case of PREV being the second scope it can't find a previous scope since there will only be one scope in the stack. So it needs getCurrentScope to find the correct scope to refer to.
This doesn't matter for RHS mentions of PREV since those don't create a scope.